### PR TITLE
Config for external content

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Header name to acquire roles from
 fcrepo_auth_header_name:
 ```
 
+Islandora takes advantage of fcrepo's external content feature.  To enable redirects / proxying, you need to configure:
+
+Where the config file gets stored:
+```
+fcrepo_allowed_external_content_file: "{{ fcrepo_config_dir }}/allowed-external-content.txt"
+```
+
+What paths/urls to expose:
+```
+fcrepo_allowed_external_content:
+  - http://localhost:8000/
+```
+
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,12 @@ fcrepo_war_path: "{{ tomcat8_home }}/webapps/fcrepo.war"
 fcrepo_home_dir: /opt/fcrepo
 fcrepo_activemq_template: activemq.xml.j2
 fcrepo_config_dir: "{{ fcrepo_home_dir }}/configs"
+
+# External content paths can be directories or urls,
+# and they MUST end in /
+fcrepo_allowed_external_content:
+  - http://localhost:8000/
+
+fcrepo_allowed_external_content_file: "{{ fcrepo_config_dir }}/allowed-external-content.txt"
+
 fcrepo_auth_header_name:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -17,3 +17,11 @@
     owner: "{{ fcrepo_user }}"
     group: "{{ fcrepo_user }}"
   notify: restart tomcat8
+
+- name: Template out allowed external content paths
+  template:
+    src: allowed-external-content.txt.j2
+    dest: "{{ fcrepo_allowed_external_content_file }}"
+    owner: "{{ fcrepo_user }}"
+    group: "{{ fcrepo_user }}"
+  notify: restart tomcat8

--- a/templates/allowed-external-content.txt.j2
+++ b/templates/allowed-external-content.txt.j2
@@ -1,0 +1,3 @@
+{% for item in fcrepo_allowed_external_content %}
+{{ item }}
+{% endfor %}


### PR DESCRIPTION
Part of https://github.com/Islandora-CLAW/CLAW/issues/1079

Templates out a config file containing paths to be proxied/redirected to.  It exposes those paths as a list in configuration.  Also, the full path+name to the config file is a variable so that it can be used when setting Java opts.

Test with https://github.com/Islandora-Devops/claw-playbook/pull/100