### PR TITLE
Allows fedora to be run off a remote database.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ fcrepo_db_user: fcrepo
 fcrepo_db_password: fcrepo
 fcrepo_db_host: "127.0.0.1"
 fcrepo_db_port: "3306"
+# user that has database create and user add privs.
+fcrepo_db_root_user: "root"
+fcrepo_db_root_password: ""
 
 # External content paths can be directories or urls,
 # and they MUST end in /

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ fcrepo_binary_directory: "{{ fcrepo_data_dir}}/binaries"
 fcrepo_war_path: "{{ tomcat8_home }}/webapps/fcrepo.war"
 fcrepo_home_dir: /opt/fcrepo
 fcrepo_activemq_template: activemq.xml.j2
+fcrepo_activemq_broker_url: "tcp://localhost:61616"
 fcrepo_config_dir: "{{ fcrepo_home_dir }}/configs"
 
 # For file-simple object persistence.
@@ -21,7 +22,7 @@ fcrepo_db_host: "127.0.0.1"
 fcrepo_db_port: "3306"
 # user that has database create and user add privs.
 fcrepo_db_root_user: "root"
-fcrepo_db_root_password: ""
+fcrepo_db_root_password: "islandora"
 
 # External content paths can be directories or urls,
 # and they MUST end in /

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -25,6 +25,7 @@
     group: "{{ fcrepo_user }}"
   notify: restart tomcat8
 
+# ADDED by dbernstein
 - name: Template out allowed external content paths
   template:
     src: allowed-external-content.txt.j2

--- a/tasks/db-mysql.yml
+++ b/tasks/db-mysql.yml
@@ -3,6 +3,10 @@
 - name: Create Fedora DB (mysql)
   mysql_db:
     name: "{{ fcrepo_db_name }}"
+    login_host: "{{ fcrepo_db_host }}"
+    login_port: "{{ fcrepo_db_port }}"
+    login_user: "{{ fcrepo_db_root_user }}"
+    login_password:  "{{ fcrepo_db_root_password }}"
     state: present
   register: fcrepo_db_exists
 
@@ -10,5 +14,10 @@
   mysql_user:
     name: "{{ fcrepo_db_user }}"
     password: "{{ fcrepo_db_password }}"
-    state: present
+    login_host: "{{ fcrepo_db_host }}"
+    login_port: "{{ fcrepo_db_port }}"
+    login_user: "{{ fcrepo_db_root_user }}"
+    login_password:  "{{ fcrepo_db_root_password }}"
     priv: "{{fcrepo_db_name}}.*:ALL"
+    state: present
+    host: "%"

--- a/tasks/db-pgsql.yml
+++ b/tasks/db-pgsql.yml
@@ -4,10 +4,18 @@
   postgresql_user:
     name: "{{ fcrepo_db_user }}"
     password: "{{ fcrepo_db_password }}"
+    login_host: "{{ fcrepo_db_host }}"
+    login_port: "{{ fcrepo_db_port }}"
+    login_user: "{{ fcrepo_db_root_user }}"
+    login_password:  "{{ fcrepo_db_root_password }}"
 
 - name: Create Fedora DB (pgsql)
   postgresql_db:
     name: "{{ fcrepo_db_name }}"
+    login_host: "{{ fcrepo_db_host }}"
+    login_port: "{{ fcrepo_db_port }}"
+    login_user: "{{ fcrepo_db_root_user }}"
+    login_password:  "{{ fcrepo_db_root_password }}"
     state: present
     owner: "{{ fcrepo_db_user }}"
   register: fcrepo_db_exists

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,3 +38,23 @@
     state: directory
     owner: "{{ fcrepo_user }}"
     group: "{{ fcrepo_user }}"
+
+- name: Install python dependencies
+  apt:
+    pkg:
+      - python-psycopg2
+      - python-mysqldb
+      - mysql-client 
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+  when: ansible_os_family == "Debian"
+
+- name: Install python dependencies 
+  yum:
+    name:
+      - python-psycopg2
+      - python-mysqldb
+      - mysql-client
+    state: present
+  when: ansible_os_family == "RedHat"

--- a/templates/activemq.xml.j2
+++ b/templates/activemq.xml.j2
@@ -17,7 +17,7 @@
         <kahaDB directory="${fcrepo.activemq.directory:ActiveMQ/kahadb}"/>
       </persistenceAdapter>
       <networkConnectors>
-        <networkConnector name="fedora_bridge" dynamicOnly="true" uri="static:(tcp://localhost:61616)">
+        <networkConnector name="fedora_bridge" dynamicOnly="true" uri="static:({{ fcrepo_activemq_broker_url }})">
           <dynamicallyIncludedDestinations>
             <topic physicalName="fedora"/>
             <queue physicalName="fedora"/>


### PR DESCRIPTION
**GitHub Issue**: n/a

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

This PR ensures that the necessary parameters are made available and packages are installed that allow fedora to run against a remote database instance.  the fedora_db_root_user is a user will database creation permissions.


# How should this be tested?
Set up a remote database instance,  override the the default parameters with appropriate values and verify that the database and users are created successfully.

# Additional Notes:

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
