### PR TITLE
Update CentOS python packages

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -54,7 +54,7 @@
   yum:
     name:
       - python-psycopg2
-      - python-mysqldb
-      - mysql-client
+      - MySQL-python
+      - mysql
     state: present
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
Fixes incorrect package names for python dependencies on CentOS
needed for fcrepo install

**GitHub Issue**: n/a


# What does this Pull Request do?

Updates CentOS python packages needed for Fedora install

# What's new?
As of #7c266bd, Python is needed for installation of Fedora.  Unfortunately, the package names were incorrect for CentOS.  This PR fixes that.

# How should this be tested?

I'm not sure.  Somehow, run the islandora-playbook referencing this PR against a CentOS machine, and see if it succeeds.

It used to fail with the message: 
```
TASK [Islandora-Devops.fcrepo : Install python dependencies] *******************
Sunday 26 January 2020  06:11:05 +0000 (0:00:00.343)       0:23:50.012 ********
fatal: [default]: FAILED! => {"changed": false, "msg": "No package matching 'python-mysqldb' found available, installed or updated", "rc": 126, "results": ["No package matching 'python-mysqldb' found available, installed or updated"]}
```

If successful, this message will no longer appear

# Additional Notes:
none

# Interested parties
@Islandora-Devops/committers
