### PR TITLE
Update to run on Ubuntu 20.04 and Tomcat 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ fcrepo_version: 5.1.0
 
 User with permissions to install:
 ```
-fcrepo_user: {{ tomcat8_server_user }}
+fcrepo_user: {{ tomcat9_server_user }}
 ```
 
 Path to put Fedora data directory (see the notes section below)
 ```
-fcrepo_data_dir: /var/lib/tomcat8/fcrepo4-data
+fcrepo_data_dir: /var/lib/tomcat9/fcrepo4-data
 ```
 
 A home directory for Fedora
@@ -33,7 +33,7 @@ fcrepo_home_dir: /opt/fcrepo
 
 Where to put the Fedora war file
 ```
-fcrepo_war_path: "{{ tomcat8_home }}/webapps/fcrepo.war"
+fcrepo_war_path: "{{ tomcat9_home }}/webapps/fcrepo.war"
 ```
 
 The activemq configuration file template name
@@ -98,7 +98,7 @@ fcrepo_allowed_external_content:
 
 ## Dependencies
 
-* islandora.tomcat8
+* islandora.tomcat9
  
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ fcrepo_allowed_external_content:
 
 ## Dependencies
 
-* islandora.tomcat9
+* islandora.tomcat8
  
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 fcrepo_version: 5.1.0
-fcrepo_user: "{{ tomcat8_server_user }}"
-fcrepo_data_dir: /var/lib/tomcat8/fcrepo4-data
+fcrepo_user: "{{ tomcat9_server_user }}"
+fcrepo_data_dir: /var/lib/tomcat9/fcrepo4-data
 fcrepo_binary_directory: "{{ fcrepo_data_dir}}/binaries"
-fcrepo_war_path: "{{ tomcat8_home }}/webapps/fcrepo.war"
+fcrepo_war_path: "{{ tomcat9_home }}/webapps/fcrepo.war"
 fcrepo_home_dir: /opt/fcrepo
 fcrepo_activemq_template: activemq.xml.j2
 fcrepo_activemq_broker_url: "tcp://localhost:61616"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,7 +7,7 @@
   with_items:
     - claw.cnd
     - fcrepo-config.xml
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 - name: Copy templated repository.json
   template:
@@ -15,7 +15,7 @@
     dest: "{{ fcrepo_home_dir }}/configs/repository.json"
     owner: "{{ fcrepo_user }}"
     group: "{{ fcrepo_user }}"
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 - name: Copy fedora activemq configuration
   template:
@@ -23,7 +23,7 @@
     dest: "{{ fcrepo_config_dir }}/activemq.xml"
     owner: "{{ fcrepo_user }}"
     group: "{{ fcrepo_user }}"
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 # ADDED by dbernstein
 - name: Template out allowed external content paths
@@ -32,4 +32,4 @@
     dest: "{{ fcrepo_allowed_external_content_file }}"
     owner: "{{ fcrepo_user }}"
     group: "{{ fcrepo_user }}"
-  notify: restart tomcat8
+  notify: restart tomcat9

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,8 +42,8 @@
 - name: Install python dependencies
   apt:
     pkg:
-      - python-psycopg2
-      - python-mysqldb
+      - python3-psycopg2
+      - python3-mysqldb
       - mysql-client 
     state: present
     update_cache: yes


### PR DESCRIPTION
**GitHub Issue**: [Update playbook to Ubuntu 20.04 Focal64](https://github.com/Islandora/documentation/issues/1792)

# What does this Pull Request do?

Update Fedora role to work with Tomcat 9 on Ubuntu 20.04 Focal64

# What's new?

Runs on Tomcat 9
Updated Ubuntu package dependencies.


# How should this be tested?

Test as part of the full playbook update. Ensure Fedora objects and binaries can be created.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
